### PR TITLE
Add cygwin to the recognized platforms.

### DIFF
--- a/L2hos.pm
+++ b/L2hos.pm
@@ -89,6 +89,9 @@ sub load {
 	} elsif ($OS eq 'darwin') {
 		require L2hos::Unix;
 		'L2hos::Unix'
+	} elsif ($OS eq 'cygwin') {
+		require L2hos::Unix;
+		'L2hos::Unix'
 	} elsif ($OS eq 'MSWin32') {
 		require L2hos::Win32;
 		'L2hos::Win32'


### PR DESCRIPTION
Cygwin is closer to Unix than Windows for basically everything but dynamic library linking.  Among other things, the concept of a "drive letter" isn't necessary.

I compiled on Cygwin and the tests pass.  I haven't tried it on any of my own files yet.