### PR TITLE
fix calling pnmcrop with a duplicated -sides option (aka PNMCROPOPT)

### DIFF
--- a/pstoimg.pin
+++ b/pstoimg.pin
@@ -1300,9 +1300,9 @@ sub crop_scale_etc {
     my $edge = $1;
     my $croparg = '';
     if($edge =~ /b/i) {
-      $croparg = "-bot -sides $PNMCROPOPT ";
+      $croparg = "-bot -sides ";
     } elsif($edge =~ /[tlr]/i) {
-      $croparg = "-$edge -sides $PNMCROPOPT ";
+      $croparg = "-$edge -sides ";
     } elsif($edge =~ /s/i) {
       #RRM: shave at most 1-2 rows of white from the bottom
 #if @pipes@


### PR DESCRIPTION
If the variable `PNMCROPOPT` is defined as `-sides` via `config/config.pl` in `pstoimg.bin`, calling
```
pnmcrop -bot -sides $PNMCROPOPT
```
will give an error, due to the duplicated option.

This probably relates to issues #40 and #41.