### PR TITLE
Propagate srcdir in perl conf script

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -35,12 +35,16 @@ SCRIPTS = latex2html texexpand pstoimg
 MODULES = l2hconf.pm
 
 # for dependencies
-wrappers = wrapper/dos.pin wrapper/macos.pin wrapper/os2.pin \
-        wrapper/unix.pin wrapper/win32.pin
+wrappers = ${srcdir}/wrapper/dos.pin ${srcdir}/wrapper/macos.pin \
+        ${srcdir}/wrapper/os2.pin ${srcdir}/wrapper/unix.pin \
+        ${srcdir}/wrapper/win32.pin
 
 # Switch for Perl Warnings; should always be on
 # temporary solution until latexhtml is cleaned up
 PERLW =# -w
+
+# Prepend current directory for the search of perl modules
+PERLI = -I.
 
 #### End of system configuration section. ####
 
@@ -49,8 +53,9 @@ ARGS=#
 
 SHELL = /bin/sh
 
+
 # Files that can be generated, but should be up to date for a distribution.
-DISTDEP = configure Makefile MANIFEST
+DISTDEP = ${srcdir}/configure Makefile ${srcdir}/MANIFEST
 
 buildcmd = config/build.pl
 BUILDOPT=# nothing special, but -devel is a good idea!
@@ -65,37 +70,38 @@ devel:
 
 # .SUFFIXES:
 
-pstoimg:  ${cfgfile} ${srcdir}/${buildcmd} pstoimg.pin ${wrappers}
-	${PERL} ${srcdir}/${buildcmd} -x ${BUILDOPT} $@
+pstoimg:  ${cfgfile} ${srcdir}/${buildcmd} ${srcdir}/pstoimg.pin ${wrappers}
+	${PERL} ${PERLI} ${srcdir}/${buildcmd} -x ${BUILDOPT} $@
 	touch pstoimg
 
-latex2html:  ${cfgfile} ${srcdir}/${buildcmd} latex2html.pin ${wrappers}
-	${PERL} ${srcdir}/${buildcmd} -x ${BUILDOPT} $@
+latex2html:  ${cfgfile} ${srcdir}/${buildcmd} ${srcdir}/latex2html.pin ${wrappers}
+	${PERL} ${PERLI} ${srcdir}/${buildcmd} -x ${BUILDOPT} $@
 	touch latex2html
 
-texexpand:  ${cfgfile} ${srcdir}/${buildcmd} texexpand.pin ${wrappers}
-	${PERL} ${srcdir}/${buildcmd} -x ${BUILDOPT} $@
+texexpand:  ${cfgfile} ${srcdir}/${buildcmd} ${srcdir}/texexpand.pin ${wrappers}
+	${PERL} ${PERLI} ${srcdir}/${buildcmd} -x ${BUILDOPT} $@
 	touch texexpand
 
 ${cfgfile}: config.status
 
-l2hconf.pm: ${cfgfile} ${srcdir}/${buildcmd} l2hconf.pin
-	${PERL} ${srcdir}/${buildcmd} ${BUILDOPT} $@
+l2hconf.pm: ${cfgfile} ${srcdir}/${buildcmd} ${srcdir}/l2hconf.pin
+	${PERL} ${PERLI} ${srcdir}/${buildcmd} ${BUILDOPT} $@
 	touch l2hconf.pm
 
 test: all
 	LATEX2HTMLDIR=$(realpath ${srcdir}); export LATEX2HTMLDIR ; \
 	latex2html='' ; \
+	builddir=`pwd` ; \
 	for file in latex2html bin/latex2html* bin/${PLAT}/latex2html*; do \
-	  test -s $$file && latex2html=$$file break ; \
+	  test -s $$builddir/$$file && latex2html=$$builddir/$$file break ; \
 	done ; \
 	if test -n "$$latex2html"; then \
 	  echo "*** Running test on $$latex2html"; \
-	  cd tests; ../$$latex2html -test_mode ${ARGS} ${TESTCASE} ; \
+	  cd ${srcdir}/tests; BUILDDIR="$$builddir" $$latex2html -test_mode ${ARGS} ${TESTCASE} ; \
 	fi
 
 test_clean:
-	cd tests ; \
+	cd ${srcdir}/tests ; \
 	for i in *.tex ; do \
 	  dir=`basename $$i .tex` ; \
 	  rm -rf $$dir ; \
@@ -110,7 +116,7 @@ test_pstoimg: pstoimg
 	done ; \
 	if test -n "$$pstoimg"; then \
 	  echo "*** Running test: $$pstoimg ${ARGS}"; \
-	  ${PERL} $$pstoimg ${ARGS} ; \
+	  ${PERL} ${PERLI} $$pstoimg ${ARGS} ; \
 	fi
 
 texlive: texlive.pm
@@ -119,17 +125,17 @@ texlive: texlive.pm
 
 check: all
 	LATEX2HTMLDIR=${srcdir}; export LATEX2HTMLDIR ; \
-	for file in versions/*.pl styles/*.perl; do \
-	  ${PERL} ${PERLW} -c $$file || exit 1; \
+	for file in ${srcdir}/versions/*.pl ${srcdir}/styles/*.perl; do \
+	  ${PERL} ${PERLI} ${PERLW} -c $$file || exit 1; \
 	done ; \
 	for file in ${SCRIPTS} ${MODULES}; do \
-	  test -s $$file && ( ${PERL} ${PERLW} -c $$file || exit 1 ); \
-	  test -s $$file.pl && ( ${PERL} ${PERLW} -c $$file.pl || exit 1 ); \
+	  test -s $$file && ( ${PERL} ${PERLI} ${PERLW} -c $$file || exit 1 ); \
+	  test -s $$file.pl && ( ${PERL} ${PERLI} ${PERLW} -c $$file.pl || exit 1 ); \
 	done ; \
 	exit 0
 
-install: all
-	${PERL} ${installcmd}
+install: all ${srcdir}/${installcmd}
+	${PERL} ${PERLI} ${srcdir}/${installcmd}
 
 # Don't cd, to avoid breaking install-sh references.
 
@@ -137,10 +143,10 @@ ${srcdir}/configure:
 	cd ${srcdir} && \
 	${AUTOCONF}
 
-Makefile: Makefile.in config.status
+Makefile: ${srcdir}/Makefile.in config.status
 	./config.status
 
-config.status: ${srcdir}/configure config/config.pl
+config.status: ${srcdir}/configure ${srcdir}/config/config.pl
 	./config.status --recheck
 
 clean mostlyclean distclean:: test_clean
@@ -151,22 +157,23 @@ distclean::
 	rm -f Makefile config.status config.cache config.log ${cfgfile}
 	rm -f test.bat install.bat
 
-MANIFEST:
+${srcdir}/MANIFEST:
 	${PERL} make_manifest \
 	  -x configure.in \
 	  -x make_manifest \
-	> MANIFEST
+	> ${srcdir}/MANIFEST
 
 # Create a distribution based on the MANIFEST file
 dist: ${DISTDEP}
 	distname=latex2html-${DISTVER} ; \
 	rm -fr $$distname; \
 	mkdir $$distname; \
-	for item in `cat MANIFEST`; do \
-	  test -d $$item && mkdir $$distname/$$item; \
-	  test -f $$item && ( \
-	    ln $$item $$distname/$$item || \
-	    { echo copying $$item instead; cp -p $$item $$distname/$$item;}; \
+	for item in `cat ${srcdir}/MANIFEST`; do \
+	  test -d "${srcdir}/$$item" && mkdir "$$distname/$$item"; \
+	  test -f "${srcdir}/$$item" && ( \
+	    ln "${srcdir}/$$item" "$$distname/$$item" || \
+	    { echo copying ${srcdir}/$$item instead; \
+	      cp -p "${srcdir}/$$item" "$$distname/$$item"; }; \
 	  ) ; \
 	done; \
 	chmod -R u+rw,go-w+rX $$distname; \

--- a/config/build.pl
+++ b/config/build.pl
@@ -231,13 +231,14 @@ exit 0;
 sub build {
   my ($script,$output,$add_header_footer,$executable) = @_;
 
-  print qq{Building "$output" from "$script.pin"\n};
+  my $sourcefilename = "$cfg{'srcdir'}${dd}$script.pin";
+  print qq{Building "$output" from "$sourcefilename"\n};
 
   my @stack = ();
   my $do_include = 1;
 
-  unless(open(IN,"<$script.pin")) {
-    print "$0: Error: Cannot read $script.pin: $!\n";
+  unless(open(IN,"<$sourcefilename")) {
+    print "$0: Error: Cannot read $sourcefilename $!\n";
     exit 1;
   }
 
@@ -268,7 +269,6 @@ sub build {
     }
     print OUT $head;
   }
-  my $sourcefilename = "$script.pin";
   $sourcefilename =~ s:^.*[\\/$dd$dd]::; # strip path
   print OUT qq{# line 1 "$sourcefilename"\n} if($opt{devel});
 

--- a/config/config.pl
+++ b/config/config.pl
@@ -508,7 +508,7 @@ $newcfg{'NULLFILE'} = L2hos->nulldev;
 my $cwd = L2hos->Cwd(); # get the current directory
 #$cwd =~ s:/:$dd:g; # beautify the path delimiter(s)
 $cwd = cwd() unless(-d $cwd); # test if it still works :-)
-$newcfg{'srcdir'} = $cwd;
+$newcfg{'srcdir'} = $opt{'SRCDIR'} || $cwd;
 
 # ----------------------------------------------------------------------------
 # win32: Windows 95, Windows NT
@@ -1952,7 +1952,7 @@ if(&is_true(&get_name('PIPES'))) {
     $newcfg{'pipes'} = 0;
   }
   else {
-    my $cmd = "echo 101" .  (" | $newcfg{'PERL'} config${dd}pipetest.pl" x 8);
+    my $cmd = "echo 101" .  (" | $newcfg{'PERL'} $newcfg{'srcdir'}${dd}config${dd}pipetest.pl" x 8);
     my $out = `$cmd`;
     chomp $out;
     if($out == 109) {
@@ -2458,7 +2458,7 @@ sub get_out_err {
   my ($cmd) = @_;
 
   # redir.pl does the redirection for us
-  unless(open(IN,"$newcfg{PERL} config${dd}redir.pl $cmd |")) {
+  unless(open(IN,"$newcfg{'PERL'} $newcfg{'srcdir'}${dd}config${dd}redir.pl $cmd |")) {
     return(255,'',$!);
   }
   my @out = ();

--- a/config/install.pl
+++ b/config/install.pl
@@ -227,9 +227,9 @@ my %Install_items = (
   'foilhtml'          => 'lib,recurse',
   # icons are teated specially below
   # the local config is also installed
-  'cfgcache.pm'       => 'plat',
+  'cfgcache.pm'       => 'plat,from=.',
   #'latex2html.config' is now l2hconf.pm
-  'l2hconf.pm'        => 'plat',
+  'l2hconf.pm'        => 'plat,from=.',
   'makemap'           => 'lib',
   'makeseg'           => 'lib,recurse',
   #'prefs.pm'          => 'lib',
@@ -278,7 +278,7 @@ if($cfg{'texlive'}) {
   }
 } else {
   foreach(@scripts) {
-    $Install_items{"$_$cfg{'exec_extension'}"} = 'bin';
+    $Install_items{"$_$cfg{'exec_extension'}"} = 'bin,from=.';
   }
 }
 
@@ -306,7 +306,7 @@ if(-d $dest2 && !-w $dest2) {
   print STDERR "Error: Cannot install icons in '$dest2': No write permission.\n";
   $dest2 = '';
 }
-my $dir = "icons";
+my $dir = "$cfg{'srcdir'}${dd}icons";
 unless(opendir(DIR,$dir)) {
   print STDERR qq{Error: Could not read directory "$dir": $!\n};
 } else {
@@ -334,7 +334,7 @@ foreach $item (sort keys %Install_items) {
     next;
   }
 
-  my $from = '.';
+  my $from = $cfg{'srcdir'} || '.';
   if($Install_items{$item} =~ /(?:^|,)from=([^,]+)(?:,|$)/) {
     $from = $1;
   }
@@ -362,7 +362,7 @@ foreach $item (sort keys %Install_items) {
     $chmod = $1;
   }
   if($Install_items{$item} =~ /recurse/) {
-    &install_recurse($item,$dest,$chmod);
+    &install_recurse("$from/$item",$dest,$chmod);
   }
   else {
     &install_file("$from/$item",$dest,$chmod);
@@ -375,7 +375,7 @@ foreach $item (sort keys %Install_items) {
 
 if($cfg{TEXPATH}) {
     print "\nNote: trying to install LaTeX2HTML style files in TeX directory tree\n     ($cfg{TEXPATH})\n";
-    my $dir = 'texinputs';
+    my $dir = "$cfg{'srcdir'}${dd}texinputs";
     my $dest = $cfg{TEXPATH};
     unless(opendir(DIR,$dir)) {
       print STDERR qq{Error: Could not read directory "$dir": $!\n};

--- a/configure
+++ b/configure
@@ -1264,6 +1264,7 @@ $PERL $srcdir/config/config.pl \
   PREFIX=$prefix \
   BINDIR=$bindir \
   LIBDIR=$libdir \
+  SRCDIR=$srcdir \
   SHLIBDIR=$shlibdir \
   WRAPPER=$enable_wrapper \
   TEXLIVE=$enable_texlive \

--- a/latex2html.pin
+++ b/latex2html.pin
@@ -120,6 +120,9 @@ if($ENV{'PERL5LIB'}) {
 } else {
   $ENV{'PERL5LIB'} = $LATEX2HTMLDIR;
 }
+# include BUILDDIR in the search path in case of out-of-tree build
+push(@INC,$ENV{'BUILDDIR'});
+$ENV{'PERL5LIB'} .= "$envkey$ENV{'BUILDDIR'}";
 
 # Local configuration, read at runtime
 # Read the $CONFIG_FILE  (usually l2hconf.pm )
@@ -463,8 +466,8 @@ if ($opt{version}) {
 }
 if ($opt{test_mode}) {
     $TITLE = 'LaTeX2HTML Test Document';
-    $TEXEXPAND = "$PERL @srcdir@${dd}texexpand@scriptext@";
-    $PSTOIMG   = "$PERL @srcdir@${dd}pstoimg@scriptext@";
+    $TEXEXPAND = "$PERL $ENV{'BUILDDIR'}${dd}texexpand@scriptext@";
+    $PSTOIMG   = "$PERL $ENV{'BUILDDIR'}${dd}pstoimg@scriptext@";
     $ICONSERVER = L2hos->path2URL("@srcdir@${dd}icons");
     $TEST_MODE  = 1;
     $RGBCOLORFILE = "@srcdir@${dd}styles${dd}rgb.txt";


### PR DESCRIPTION
Out-of-tree configure failed as the perl script was expecting configure to be called from the top directory and not in a dedicated build directory.

We use the srcdir variable defined by configure to propagate to config.pl, and keep the cmd variable approach as a fallback.