### PR TITLE
Propagate listing options

### DIFF
--- a/Changes
+++ b/Changes
@@ -84,6 +84,7 @@
 #  bv = Boris Veytsman <boris@plmsc.psu.edu>
 #  kr = Keith Refson <Keith.Refson@earth.ox.ac.uk>
 #  uw = Uli Wortmann <uli12@bonk.ethz.ch>
+#  cf = Clément FOYER <clement.foyer@univ-reims.fr>
 #
 #
 #------------------- Test Suite Manifest ----------------------------------
@@ -113,8 +114,9 @@
 # the top.
 #
 #
-#		- allow configure and make out-of-tree
-#		  Clément FOYER, Université de Reims Champagne-Ardenne, France
+#	cf	- propagate configuration options between the different styles when
+#		  using the listing commands \lstdeclarestyle and \lstset.
+#	cf	- allow configure and make out-of-tree
 #		- fix collision in anchor ids for section links
 #		- remove <STRONG> markup for author
 #

--- a/styles/listings.perl
+++ b/styles/listings.perl
@@ -182,7 +182,7 @@ sub process_lstlisting {
     } else {
       &replace_html_special_chars;
     }
-    s/\n$//;		# vertical space is contributed by </PRE> already.
+    s/\n*$//;		# vertical space is contributed by </PRE> already.
     $contents = $_;
   }
 
@@ -419,7 +419,7 @@ sub process_lstlisting {
       $_ = `$SRCHILITE $HILITE_OPTS --failsafe $lst_lnum -s $lst_lang -i .$dd${PREFIX}hilite.in`;
     }
     unlink (".$dd${PREFIX}hilite.in");
-    s/\n$//;				# remove trailing vertical space
+    s/\n*$//;				# remove trailing vertical space
   } else {
     # Evtl generate line numbers by builtin engine
     if ($curopts{'numbers'} eq 'left') {
@@ -448,7 +448,7 @@ sub process_lstlisting {
       $lst_last_counter = $counter;
       $lst_auto_counter{$lst_name} = $lst_last_counter
 	if $curopts{'firstnumber'} eq 'auto' && $lst_name ne '';
-      $cline =~ s/\n$//;
+      $cline =~ s/\n*$//;
       $_ = "<TABLE><TR><TD>"
 	.$lst_pre.$_.$lst_post."</TD><TD ALIGN=\"RIGHT\">"
 	.$lst_pre.$cline.$lst_post."</TD></TR></TABLE>";
@@ -578,7 +578,7 @@ sub process_lstinline {
     unlink (".$dd${PREFIX}hilite.in");
     $contents =~ s/^.*?<pre>//s;	# remove obstructive starting stuff
     $contents =~ s/<\/pre>.*?$//s;	# remove obstructive trailing stuff
-    $contents =~ s/\n$//;		# remove trailing vertical space
+    $contents =~ s/\n*$//;		# remove trailing vertical space
   }
 
   # Make the actual lstinline output

--- a/styles/listings.perl
+++ b/styles/listings.perl
@@ -76,6 +76,8 @@ sub do_cmd_lstset {
   # In preamble this just initializes the defaults
   if ($PREAMBLE) {
     my(%opts) = &lst_parse_options($option);
+    @{$lstset_style{$style}}{keys %{$lstset_style{$opts{'style'}}}} =
+        (values %{$lstset_style{$opts{'style'}}}) if (exists($opts{'style'}));
     @lstset_current{keys %opts} = (values %opts);
     return $outer;
   }
@@ -102,6 +104,8 @@ sub do_cmd_lstdefinestyle {
   # In preamble this just creates the new style
   if ($PREAMBLE) {
     my(%opts) = &lst_parse_options($option);
+    @{$lstset_style{$style}}{keys %{$lstset_style{$opts{'style'}}}} =
+        (values %{$lstset_style{$opts{'style'}}}) if (exists($opts{'style'}));
     @{$lstset_style{$style}}{keys %opts} = (values %opts);
     return $outer;
   }


### PR DESCRIPTION
When defining styles, they may be cascading and inheriting one from another (and the previous style should always be defined in a proper latex file).

This patch propagates the characteristics of already defined styles to new ones (if they depend on the previous one), in order to propagate things like "language" key, or colour configuration all the way down to the hilighter.