### PR TITLE
Use path variable

### DIFF
--- a/styles/harvard.perl
+++ b/styles/harvard.perl
@@ -5,10 +5,10 @@ package main;
 # Setting $HARVARD makes natbib.perl behave differently
 $HARVARD=1;
 
-foreach $dir (split(/:/,$LATEX2HTMLSTYLES)) {
-    if (-f "$dir/natbib.perl") {
-	print "Loading $dir/natbib.perl\n";
-	require "$dir/natbib.perl";
+foreach $dir (split(/$envkey/,$LATEX2HTMLSTYLES)) {
+    if (-f "$dir${dd}natbib.perl") {
+	print "Loading $dir${dd}natbib.perl\n";
+	require "$dir${dd}natbib.perl";
 	$styles_loaded{"natbib"}=1;
 	last
 	}

--- a/styles/listings.perl
+++ b/styles/listings.perl
@@ -164,11 +164,11 @@ sub process_lstlisting {
     }
     my($inputpath) = $curopts{'inputpath'};
     my($found) = 0;
-    foreach $dir ("$texfilepath", split(/:/,$ENV{'TEXINPUTS'})) { 
-      if (-f ($_ = "$dir/$inputpath/$file") ||
-	  -f ($_ = "$dir/$inputpath/$file2") ||
-	  -f ($_ = "$dir/$file") ||
-	  -f ($_ = "$dir/$file2")) {
+    foreach $dir ("$texfilepath", split(/$envkey/,$ENV{'TEXINPUTS'})) {
+      if (-f ($_ = "$dir$dd$inputpath$dd$file") ||
+	  -f ($_ = "$dir$dd$inputpath$dd$file2") ||
+	  -f ($_ = "$dir$dd$file") ||
+	  -f ($_ = "$dir$dd$file2")) {
 	$found = 1;
 	# overread $_ with file contents
 	&slurp_input($_);


### PR DESCRIPTION
Some path were being parsed and sed'ed with the use of $envkey or $dd, which could have created issues (I guess, otherwise there wouldn't have been these variables defined). Anyhow, when I bumped into it, I updated the code to use the variables.