### PR TITLE
Fix lstinline parsing

### DIFF
--- a/latex2html.pin
+++ b/latex2html.pin
@@ -1658,6 +1658,7 @@ sub pre_process {
 	    #RRM: retain knowledge of whether \verb* or \verb
 	    $vb_mark = ($1 =~/^\s*\*/? $verbstar_mark : $verb_mark);
 	}
+	$del =~ tr/{([/})]/;
 	$esc_del = &escape_rx_chars($del);
 	$esc_del = '' if (length($del) > 2);
 

--- a/latex2html.pin
+++ b/latex2html.pin
@@ -1627,14 +1627,14 @@ sub pre_process {
     ##RRM: can this be speeded up using a list ??
     my $vbmark = $verb_mark;
     while (s/\\verb(\t*\*\t*)(\S)/"<verb$1".++$id.">$2"/e ||
-	    s/\\verb()(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$2"/e ||
-	    s/\\verb(\t\t*)([^*\s])/"<verb$1".++$id.">$2"/e ||
-	    s/\\(lstinline)\s*(\[[^]]*\])?\s*(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$3"/e ||
-	    s/\\(lstinline)\s*(\[[^]]*\])?\s*([^*\s])/"<verb$1".++$id.">$3"/e ||
-	    s/\\(mintinline)\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$4"/e ||
-	    s/\\(mintinline)\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*([^*\s])/"<verb$1".++$id.">$4"/e ||
-	    s/\\(mint)\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$4"/e ||
-	    s/\\(mint)\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*([^*\s])/"<verb$1".++$id.">$4"/e) {
+	    s/\\verb\b()(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$2"/e ||
+	    s/\\verb\b(\t\t*)([^*\s])/"<verb$1".++$id.">$2"/e ||
+	    s/\\(lstinline)\b\s*(\[[^]]*\])?\s*(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$3"/e ||
+	    s/\\(lstinline)\b\s*(\[[^]]*\])?\s*([^*\s])/"<verb$1".++$id.">$3"/e ||
+	    s/\\(mintinline)\b\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$4"/e ||
+	    s/\\(mintinline)\b\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*([^*\s])/"<verb$1".++$id.">$4"/e ||
+	    s/\\(mint)\b\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*(\;SPM\w+\;|[^a-zA-Z*\s])/"<verb$1".++$id.">$4"/e ||
+	    s/\\(mint)\b\s*(\[[^]]*\])?\s*(\{[^}]*\})\s*([^*\s])/"<verb$1".++$id.">$4"/e) {
 
 	if ($1 eq 'lstinline') {
 	    #SGE: retain knowledge and options of \lstinline


### PR DESCRIPTION
I had some issues with parsing of `\lstinline` commands.

First issue was the delimiter, like for `\verb` is expecting to be kept for opening and closing, while it is allowed to pass a parameter with '{}'; I updated the code to allow such use.

Second issue is when a command has been defined/redefined and has the same first characters as any of the verb/listing's family commands, then the first character following the command will be considered as the delimiting token, which is erroneous. I added a zero-width boundary meta-character to the regex to avoid such issues. Maybe a better approach would be to first deal with user defined/redefined commands.